### PR TITLE
Fixed typo in a name of zodiac sign

### DIFF
--- a/commands/horoscope/index.js
+++ b/commands/horoscope/index.js
@@ -50,7 +50,7 @@ module.exports = {
 				end: [11, 22]
 			},
 			{ 
-				name: "Sagitarius",
+				name: "Sagittarius",
 				start: [11, 23],
 				end: [12, 21]
 			},


### PR DESCRIPTION
"Sagittarius" is written with two t's. Now it should fetch a horoscope for this zodiac sign.

[Before](http://horoscope-api.herokuapp.com/horoscope/today/sagitarius)

[Now](http://horoscope-api.herokuapp.com/horoscope/today/sagittarius)