### PR TITLE
Found Bug and fixed it (in $weather)

### DIFF
--- a/commands/weather/index.js
+++ b/commands/weather/index.js
@@ -196,7 +196,7 @@ module.exports = {
 	
 		let plusTime = "";
 		if (typeof number === "number") {
-			const time = new sb.Date(topData[type].data[number].time * 1000).setTimezoneOffset(topData.offset * 60).addDays(-1);
+			const time = new sb.Date(topData[type].data[number].time * 1000).setTimezoneOffset(topData.offset * 60);
 			if (type === "hourly") {
 				plusTime = " (" + time.format("H:00") + " local time)";
 			}


### PR DESCRIPTION
I realized, that when using the weather-command with day+1 (`$weather day+1`)  it gets you the weather forecast for the next day, but the written date is from today.
If you use day+0 (`$weather day+0`) you get the weather for today, but the date is from yesterday.
So I think removing this should fix it.

I was only able to compare the weather forecast via the temperature range, because I don't have access to the DarkSky-API (_which is closing at the end of 2021_) and the other weather forecast information is only displayed as a graph on the website.

Have a great day :)