### PR TITLE
Update slug regex

### DIFF
--- a/commands/downloadclip/index.js
+++ b/commands/downloadclip/index.js
@@ -16,7 +16,7 @@ module.exports = {
 			};
 		}
 
-		const slug = rawSlug.match(/^[a-zA-z]+(-[\-a-zA-Z0-9]{16})?$/)?.[0];
+		const slug = rawSlug.match(/^[a-zA-z]+(-[\_\-a-zA-Z0-9]{16})?$/)?.[0];
 		if (!slug) {
 			return {
 				success: false,


### PR DESCRIPTION
Clips can also have underscores like this slug: `AstuteBrainyDelicataOSsloth-_MWRg3W6tT1TBIkJ`

![FarmingCommits](https://cdn.betterttv.net/emote/5ed57f8bfdee545e3065efcb/1x)