### PR TITLE
Wrong unit for timezone_offset used

### DIFF
--- a/commands/weather/index.js
+++ b/commands/weather/index.js
@@ -315,7 +315,7 @@ module.exports = {
 
 		let plusTime;
 		if (typeof number === "number") {
-			const time = new sb.Date(target.dt * 1000).setTimezoneOffset(data.timezone_offset/60);
+			const time = new sb.Date(target.dt * 1000).setTimezoneOffset(data.timezone_offset / 60);
 			if (type === "hourly") {
 				plusTime = ` (${time.format("H:00")} local time)`;
 			}

--- a/commands/weather/index.js
+++ b/commands/weather/index.js
@@ -315,7 +315,7 @@ module.exports = {
 
 		let plusTime;
 		if (typeof number === "number") {
-			const time = new sb.Date(target.dt * 1000).setTimezoneOffset(data.timezone_offset);
+			const time = new sb.Date(target.dt * 1000).setTimezoneOffset(data.timezone_offset/60);
 			if (type === "hourly") {
 				plusTime = ` (${time.format("H:00")} local time)`;
 			}


### PR DESCRIPTION
sb.Date().setTimezoneOffset() expects minutes, but OpenWeather-API uses seconds

![image](https://user-images.githubusercontent.com/36089973/122655626-079b2c00-d154-11eb-8e74-5297a6e86273.png)
