### PR TITLE
MJS refactor experiment

### DIFF
--- a/got/commander-root/index.js
+++ b/got/commander-root/index.js
@@ -1,0 +1,9 @@
+export default {
+	name: "CommanderRoot",
+	optionsType: "object",
+	options: {
+		prefixUrl: "https://twitch-tools.rootonline.de"
+	},
+	parent: "GenericAPI",
+	description: null
+};

--- a/got/fake-agent/index.js
+++ b/got/fake-agent/index.js
@@ -1,0 +1,11 @@
+export default {
+	name: "FakeAgent",
+	optionsType: "object",
+	options: {
+		headers: {
+			"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.182 Safari/537.36"
+		}
+	},
+	parent: "Global",
+	description: null
+};

--- a/got/generic-api/index.js
+++ b/got/generic-api/index.js
@@ -1,0 +1,22 @@
+export default {
+	name: "GenericAPI",
+	optionsType: "function",
+	options: (() => ({
+		mutableDefaults: true,
+		throwHttpErrors: true,
+		hooks: {
+			beforeError: [
+				(e) => new sb.errors.GenericRequestError({
+					body: e.response?.body ?? null,
+					statusCode: e.response?.statusCode,
+					statusMessage: e.response?.statusMessage,
+					hostname: e.options?.url?.hostname,
+					message: e.message,
+					stack: e.stack
+				})
+			]
+		}
+	})),
+	parent: "Global",
+	description: null
+};

--- a/got/global/index.js
+++ b/got/global/index.js
@@ -1,0 +1,38 @@
+export default {
+	name: "Global",
+	optionsType: "function",
+	options: (() => ({
+		responseType: "json",
+		retry: 0,
+		timeout: 30000,
+		mutableDefaults: true,
+		throwHttpErrors: false,
+		headers: {
+			"User-Agent": sb.Config.get("DEFAULT_USER_AGENT")
+		},
+		hooks: {
+			beforeError: [
+				async (err) => {
+					if (!err || err.code !== "ETIMEDOUT" || typeof globalThis?.sb?.Logger?.logError !== "function") {
+						return err;
+					}
+
+					await sb.Logger.logError("Request", err, {
+						origin: "External",
+						context: {
+							code: err.code,
+							responseType: err.options?.responseType ?? null,
+							timeout: err.options?.timeout ?? null,
+							url: err.options?.url?.toString?.() ?? null
+						},
+						arguments: null
+					});
+
+					return err;
+				}
+			]
+		}
+	})),
+	parent: null,
+	description: "Global definition - template for all others"
+};

--- a/got/helix/index.js
+++ b/got/helix/index.js
@@ -1,0 +1,24 @@
+export default {
+	name: "Helix",
+	optionsType: "function",
+	options: (() => {
+		if (!sb.Config.has("TWITCH_CLIENT_ID")) {
+			throw new Error("Helix sb.Got instance cannot initialize - missing client-id");
+		}
+
+		const token = sb.Config.get("TWITCH_APP_ACCESS_TOKEN", false) ?? sb.Config.get("TWITCH_OAUTH", false);
+		if (!token) {
+			throw new Error("Helix sb.Got instance cannot initialize - missing token");
+		}
+
+		return {
+			prefixUrl: "https://api.twitch.tv/helix",
+			headers: {
+				"Client-ID": sb.Config.get("TWITCH_CLIENT_ID"),
+				Authorization: `Bearer ${token}`
+			}
+		};
+	}),
+	parent: "Global",
+	description: "Twitch Helix API"
+};

--- a/got/index.js
+++ b/got/index.js
@@ -1,5 +1,31 @@
-import * as Test from "./test/index.js";
+import * as CommanderRoot from "./commander-root/index.js";
+import * as FakeAgent from "./fake-agent/index.js";
+import * as GenericAPI from "./generic-api/index.js";
+import * as Global from "./global/index.js";
+import * as Helix from "./helix/index.js";
+import * as Kraken from "./kraken/index.js";
+import * as Leppunen from "./leppunen/index.js";
+import * as Reddit from "./reddit/index.js";
+import * as Speedrun from "./speedrun/index.js";
+import * as SRA from "./sra/index.js";
+import * as Supibot from "./supibot/index.js";
+import * as Supinic from "./supinic/index.js";
+import * as V5 from "./v5/index.js";
+import * as Vimeo from "./vimeo/index.js";
 
-export {
-	Test
-};
+export const Got = [
+	CommanderRoot,
+	FakeAgent,
+	GenericAPI,
+	Global,
+	Helix,
+	Kraken,
+	Leppunen,
+	Reddit,
+	Speedrun,
+	SRA,
+	Supibot,
+	Supinic,
+	V5,
+	Vimeo
+];

--- a/got/kraken/index.js
+++ b/got/kraken/index.js
@@ -1,0 +1,19 @@
+export default {
+	name: "Kraken",
+	optionsType: "function",
+	options: (() => {
+		if (!sb.Config.has("TWITCH_CLIENT_ID")) {
+			throw new Error("Kraken sb.Got instance cannot initialize - missing client-id");
+		}
+
+		return {
+			prefixUrl: "https://api.twitch.tv/kraken",
+			headers: {
+				Accept: "application/vnd.twitchtv.v5+json",
+				"Client-ID": sb.Config.get("TWITCH_CLIENT_ID")
+			}
+		};
+	}),
+	parent: "Global",
+	description: "Twitch Kraken API"
+};

--- a/got/leppunen/index.js
+++ b/got/leppunen/index.js
@@ -1,0 +1,9 @@
+export default {
+	name: "Leppunen",
+	optionsType: "object",
+	options: {
+		prefixUrl: "https://api.ivr.fi"
+	},
+	parent: "Global",
+	description: "IVR"
+};

--- a/got/reddit/index.js
+++ b/got/reddit/index.js
@@ -1,0 +1,12 @@
+export default {
+	name: "Reddit",
+	optionsType: "object",
+	options: {
+		prefixUrl: "https://www.reddit.com/r/",
+		headers: {
+			Cookie: "_options={%22pref_quarantine_optin%22:true};"
+		}
+	},
+	parent: "Global",
+	description: null
+};

--- a/got/speedrun/index.js
+++ b/got/speedrun/index.js
@@ -1,0 +1,10 @@
+export default {
+	name: "Speedrun",
+	optionsType: "object",
+	options: {
+		prefixUrl: "https://www.speedrun.com/api/v1",
+		timeout: 30000
+	},
+	parent: "GenericAPI",
+	description: null
+};

--- a/got/sra/index.js
+++ b/got/sra/index.js
@@ -1,0 +1,9 @@
+export default {
+	name: "SRA",
+	optionsType: "object",
+	options: {
+		prefixUrl: "https://some-random-api.ml"
+	},
+	parent: "GenericAPI",
+	description: "SRA = Some Random API (https://some-random-api.ml/)"
+};

--- a/got/supibot/index.js
+++ b/got/supibot/index.js
@@ -1,0 +1,15 @@
+export default {
+	name: "Supibot",
+	optionsType: "function",
+	options: (() => {
+		const secure = sb.Config.get("SUPIBOT_API_SECURE", false) ?? false;
+		const protocol = (secure) ? "https" : "http";
+		const port = sb.Config.get("SUPIBOT_API_PORT", false) ?? 80;
+
+		return {
+			prefixUrl: `${protocol}://localhost:${port}`
+		};
+	}),
+	parent: "Global",
+	description: null
+};

--- a/got/supinic/index.js
+++ b/got/supinic/index.js
@@ -1,0 +1,10 @@
+export default {
+	name: "Supinic",
+	optionsType: "object",
+	options: {
+		prefixUrl: "http://192.168.1.101/api",
+		timeout: 30000
+	},
+	parent: "Global",
+	description: null
+};

--- a/got/test/index.js
+++ b/got/test/index.js
@@ -1,5 +1,0 @@
-export default {
-	Name: "XD",
-	Definition: () => "penis",
-	Type: "function"
-};

--- a/got/v5/index.js
+++ b/got/v5/index.js
@@ -1,0 +1,13 @@
+export default {
+	name: "V5",
+	optionsType: "function",
+	options: (() => ({
+		prefixUrl: "https://api.twitch.tv/v5",
+		headers: {
+			Accept: "application/vnd.twitchtv.v5+json",
+			"Client-ID": sb.Config.get("TWITCH_CLIENT_ID")
+		}
+	})),
+	parent: "Global",
+	description: null
+};

--- a/got/vimeo/index.js
+++ b/got/vimeo/index.js
@@ -1,0 +1,12 @@
+export default {
+	name: "Vimeo",
+	optionsType: "function",
+	options: (() => ({
+		prefixUrl: "https://api.vimeo.com",
+		headers: {
+			Authorization: `Bearer ${sb.Config.get("VIMEO_API_KEY")}`
+		}
+	})),
+	parent: "Global",
+	description: null
+};

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import * as got from "./got/index.js";
+import { Got } from "./got/index.js";
+
 export {
-	got
+	Got
 };

--- a/package.json
+++ b/package.json
@@ -13,5 +13,10 @@
     "mocha": "^8.4.0",
     "supi-core": "github:Supinic/supi-core"
   },
-  "dependencies": {}
+  "name": "supibot-package-manager",
+  "version": "1.0.0",
+  "main": "index.js",
+  "repository": "https://github.com/Supinic/supibot-package-manager",
+  "author": "Supinic <supinic@protonmail.com>",
+  "license": "AGPL-3.0"
 }


### PR DESCRIPTION
- adds the definitions of `got` as ES6 modules (MJS)
- should be able to dynamic-import these from other modules (such as `supi-core`)