### PR TITLE
Add Voice of America to Turkish news sources

### DIFF
--- a/commands/news/index.js
+++ b/commands/news/index.js
@@ -242,6 +242,13 @@ module.exports = {
 						path: null,
 						endpoints: ["turkiye_articles.rss"],
 						helpers: ["caglapickaxe", "cgpx"]
+					},
+					{
+						name: "Amerika'nın Sesi",
+						url: "https://www.amerikaninsesi.com",
+						path: "api",
+						endpoints: ["zv$vteottq"],
+						helpers: ["caglapickaxe", "cgpx"]
 					}
 				]
 			},


### PR DESCRIPTION
Adds Voice of America (_Amerika'nın Sesi_) to Turkish news sources.