### PR TITLE
added `abb execute` subcommand

### DIFF
--- a/commands/aliasbuildingblock/index.js
+++ b/commands/aliasbuildingblock/index.js
@@ -172,16 +172,10 @@ module.exports = {
 						};
 					}
 
-					if (context.append.pipe && !commandData.Flags.pipe)
+					if (context.append.pipe && !commandData.Flags.pipe) {
 						return {
 							success: false,
 							reply: `Cannot use the ${invocation} command inside of a pipe, despite being wrapped in a run command!`
-						};
-					}
-					else {
-						return {
-							success: false,
-							reply: `This command can only be used within pipes!.`
 						};
 					}
 

--- a/commands/aliasbuildingblock/index.js
+++ b/commands/aliasbuildingblock/index.js
@@ -172,13 +172,11 @@ module.exports = {
 						};
 					}
 
-					if (context.append.pipe) {
-						if (!commandData.Flags.pipe) {
-							return {
-								success: false,
-								reply: `Cannot use the ${invocation} command inside of a pipe, despite being wrapped in a run command!`
-							};
-						}
+					if (context.append.pipe && !commandData.Flags.pipe)
+						return {
+							success: false,
+							reply: `Cannot use the ${invocation} command inside of a pipe, despite being wrapped in a run command!`
+						};
 					}
 					else {
 						return {

--- a/commands/aliasbuildingblock/index.js
+++ b/commands/aliasbuildingblock/index.js
@@ -161,7 +161,7 @@ module.exports = {
 					["$abb execute -- abb say test", "test"],
 					["$pipe js \"rl\" | abb exec -- | tt fancy", "(2𝔂, 292𝓭 𝓪𝓰𝓸) 𝓵𝓮𝓹𝓹𝓾𝓷𝓮𝓷: 𝓸𝓴"]
 				],
-				execute: (context, ...args) => {
+				execute: async (context, ...args) => {
 					let [ invocation, ...commandArgs ] = args;
 					const commandData = sb.Command.get(invocation);
 


### PR DESCRIPTION
There's no way to properly execute a command from a pipe at the moment. All the pipe hacks are pretty complex, prone to errors and are inconvenient, since they need multiple aliases to work.
Can't test it, so not sure if it works Clueless