### PR TITLE
Remove Ugandan News

### DIFF
--- a/commands/news/definitions.json
+++ b/commands/news/definitions.json
@@ -26,19 +26,6 @@
     ]
   },
   {
-    "code": "ug",
-    "language": "swahili",
-    "sources": [
-      {
-        "name": "Bukedde Online",
-        "url": "https://www.bukedde.co.ug",
-        "path": "feed",
-        "endpoints": ["rss"],
-        "helpers": ["supinic"]
-      }
-    ]
-  },
-  {
     "code": "es",
     "language": "spanish",
     "sources": [


### PR DESCRIPTION
RSS endpoint does not exist anymore + no worthy replacements that I could find.
Al Jazeera has Ugandan news, but I couldn't find how to get country-specific news from their RSS; just ALL.