### PR TITLE
Fix United Kingdom country code

### DIFF
--- a/commands/news/definitions.json
+++ b/commands/news/definitions.json
@@ -725,7 +725,7 @@
     ]
   },
   {
-    "code": "uk",
+    "code": "gb",
     "language": "english",
     "sources": [
       {


### PR DESCRIPTION
As per the UN country codes + ISO codes, the correct country code for the UK is GB