### PR TITLE
Fix for updated `got` module

### DIFF
--- a/commands/cloudflarestatus/index.js
+++ b/commands/cloudflarestatus/index.js
@@ -13,8 +13,12 @@ module.exports = {
 			url: "https://yh6f0r4529hb.statuspage.io/api/v2/summary.json",
 			responseType: "json",
 			throwHttpErrors: false,
-			retry: 0,
-			timeout: 5000
+			retry: {
+				limit: 0
+			},
+			timeout: {
+				request: 5000
+			}
 		});
 
 		const { incidents, page, status, scheduled_maintenances: maintenances } = response.body;

--- a/commands/crypto/index.js
+++ b/commands/crypto/index.js
@@ -17,7 +17,9 @@ module.exports = {
 				fsym: symbol,
 				tsyms: "USD,EUR"
 			},
-			timeout: 10000,
+			timeout: {
+				request: 10000
+			},
 			headers: {
 				Authorization: `Apikey ${sb.Config.get("API_CRYPTO_COMPARE")}`
 			}
@@ -41,8 +43,12 @@ module.exports = {
 						method: "HEAD",
 						url: `https://www.coindesk.com/price/${symbol.toLowerCase()}`,
 						throwHttpErrors: false,
-						timeout: 10_000,
-						retry: 0,
+						timeout: {
+							request: 10_000
+						},
+						retry: {
+							limit: 0
+						},
 						headers: {
 							Referer: "https://www.coindesk.com/"
 						}

--- a/commands/cryptowallet/index.js
+++ b/commands/cryptowallet/index.js
@@ -71,7 +71,9 @@ module.exports = {
 				fsym: symbol,
 				tsyms: "USD,EUR"
 			},
-			timeout: 10000,
+			timeout: {
+				request: 10000
+			},
 			headers: {
 				Authorization: `Apikey ${sb.Config.get("API_CRYPTO_COMPARE")}`
 			}

--- a/commands/dalle/index.js
+++ b/commands/dalle/index.js
@@ -139,7 +139,9 @@ module.exports = {
 			json: {
 				prompt: query
 			},
-			timeout: 300_000,
+			timeout: {
+				request: 300_000
+			},
 			throwHttpErrors: false
 		});
 

--- a/commands/define/index.js
+++ b/commands/define/index.js
@@ -59,8 +59,12 @@ module.exports = {
 				term: query
 			},
 			throwHttpErrors: false,
-			retry: 0,
-			timeout: 5000
+			retry: {
+				limit: 0
+			},
+			timeout: {
+				request: 5000
+			}
 		});
 
 		const result = [];

--- a/commands/githubstatus/index.js
+++ b/commands/githubstatus/index.js
@@ -11,8 +11,12 @@ module.exports = {
 	Code: (async function githubStatus () {
 		const response = await sb.Got("GenericAPI", {
 			url: "https://www.githubstatus.com/history.json",
-			retry: 0,
-			timeout: 5000
+			retry: {
+				limit: 0
+			},
+			timeout: {
+				request: 5000
+			}
 		});
 
 		const { components, page_status: pageStatus } = response.body;

--- a/commands/liveuamap/index.js
+++ b/commands/liveuamap/index.js
@@ -41,7 +41,9 @@ module.exports = {
 				response = await sb.Got("FakeAgent", {
 					url: `https://liveuamap.com/${languageCode}`,
 					responseType: "text",
-					timeout: 60_000
+					timeout: {
+						request: 60_000
+					}
 				});
 			}
 			catch (e) {

--- a/commands/necrodancer/index.js
+++ b/commands/necrodancer/index.js
@@ -68,8 +68,12 @@ module.exports = {
 					zone: args
 				}),
 				throwHttpErrors: false,
-				timeout: 30_000,
-				retry: 0
+				timeout: {
+					request: 30_000
+				},
+				retry: {
+					limit: 0
+				}
 			}).json();
 
 			if (result.success) {
@@ -159,8 +163,12 @@ module.exports = {
 					command: "request"
 				}),
 				throwHttpErrors: false,
-				timeout: 30_000,
-				retry: 0
+				timeout: {
+					request: 30_000
+				},
+				retry: {
+					limit: 0
+				}
 			}).json();
 		}
 		catch (e) {

--- a/commands/news/currents-api.js
+++ b/commands/news/currents-api.js
@@ -18,8 +18,12 @@ module.exports = {
 				},
 				throwHttpErros: false,
 				responseType: "json",
-				retry: 0,
-				timeout: 2500
+				retry: {
+					limit: 0
+				},
+				timeout: {
+					request: 2500
+				}
 			});
 		}
 		catch (e) {

--- a/commands/stock/index.js
+++ b/commands/stock/index.js
@@ -56,7 +56,9 @@ module.exports = {
 			: findSymbol(input) ?? args[0];
 
 		const { "Global Quote": rawData } = await sb.Got({
-			retry: 0,
+			retry: {
+				limit: 0
+			},
 			throwHttpErrors: false,
 			url: "https://www.alphavantage.co/query",
 			searchParams: {

--- a/commands/urban/index.js
+++ b/commands/urban/index.js
@@ -32,8 +32,12 @@ module.exports = {
 				term
 			},
 			throwHttpErrors: false,
-			retry: 0,
-			timeout: this.staticData.timeout
+			retry: {
+				limit: 0
+			},
+			timeout: {
+				request: this.staticData.timeout
+			}
 		});
 
 		if (response.statusCode === 500) {
@@ -43,8 +47,12 @@ module.exports = {
 					api_key: this.staticData.fauxKey,
 					term
 				},
-				retry: 0,
-				timeout: this.staticData.timeout
+				retry: {
+					limit: 0
+				},
+				timeout: {
+					request: this.staticData.timeout
+				}
 			});
 
 			const match = autocompleteResponse.body.results.find(i => i.term.toLowerCase() === lowerTerm);

--- a/commands/weather/index.js
+++ b/commands/weather/index.js
@@ -281,7 +281,9 @@ module.exports = {
 				url: "https://api.openweathermap.org/data/2.5/air_pollution",
 				responseType: "json",
 				throwHttpErrors: false,
-				timeout: 60_000,
+				timeout: {
+					request: 60_000
+				},
 				searchParams: {
 					lat: coords.lat,
 					lon: coords.lng,
@@ -316,7 +318,9 @@ module.exports = {
 				url: "https://api.openweathermap.org/data/2.5/onecall",
 				responseType: "json",
 				throwHttpErrors: false,
-				timeout: 60_000,
+				timeout: {
+					request: 60_000
+				},
 				searchParams: {
 					lat: coords.lat,
 					lon: coords.lng,

--- a/got/global/index.mjs
+++ b/got/global/index.mjs
@@ -3,8 +3,12 @@ export default {
 	optionsType: "function",
 	options: (() => ({
 		responseType: "json",
-		retry: 0,
-		timeout: 30000,
+		retry: {
+			limit: 0
+		},
+		timeout: {
+			request: 30000
+		},
 		mutableDefaults: true,
 		throwHttpErrors: false,
 		headers: {

--- a/got/raspberry-pi-4/index.mjs
+++ b/got/raspberry-pi-4/index.mjs
@@ -3,7 +3,9 @@ export default {
 	optionsType: "object",
 	options: {
 		prefixUrl: "http://192.168.1.102:11111/proxy",
-		timeout: 10000
+		timeout: {
+			request: 10000
+		}
 	},
 	parent: "GenericAPI",
 	description: null

--- a/got/speedrun/index.mjs
+++ b/got/speedrun/index.mjs
@@ -3,7 +3,9 @@ export default {
 	optionsType: "object",
 	options: {
 		prefixUrl: "https://www.speedrun.com/api/v1",
-		timeout: 30000
+		timeout: {
+			request: 30000
+		}
 	},
 	parent: "GenericAPI",
 	description: null

--- a/got/supinic/index.mjs
+++ b/got/supinic/index.mjs
@@ -3,7 +3,9 @@ export default {
 	optionsType: "object",
 	options: {
 		prefixUrl: "http://192.168.1.101/api",
-		timeout: 30000
+		timeout: {
+			request: 30000
+		}
 	},
 	parent: "Global",
 	description: null

--- a/got/twitch-gql/index.mjs
+++ b/got/twitch-gql/index.mjs
@@ -15,7 +15,7 @@ export default {
 
 		return {
 			method: "POST",
-			url: "https://gql.twitch.tv/gql",
+			prefixUrl: "https://gql.twitch.tv/gql",
 			responseType: "json",
 			headers: {
 				Accept: "*/*",


### PR DESCRIPTION
The options `retry` and `timeout` have to be of type object.
There are multiple options for timeout and retry, e.g. timeout can contain `request`, `lookup`, `connect` and so on. For more, read [this for retry](https://github.com/sindresorhus/got/blob/HEAD/documentation/7-retry.md#retry) and [this for timeout](https://github.com/sindresorhus/got/blob/HEAD/documentation/6-timeout.md) options.

I suppose, that just using `request: 123` for timeout should be fine.

See also: Supinic/supi-core#35