### PR TITLE
Better responses for `channelfounderlist` command

### DIFF
--- a/commands/channelfounderlist/index.js
+++ b/commands/channelfounderlist/index.js
@@ -21,15 +21,31 @@ module.exports = {
 
 		const channel = sb.Channel.normalizeName(channelName ?? context.channel.Name);
 		const response = await sb.Got("Leppunen", `v2/twitch/founders/${channel}`);
+		const { error } = response.body;
 		if (response.statusCode === 404) {
+			if (error?.message?.includes("does not exist")) {
+				return {
+					success: false,
+					reply: `There is no such channel with that name!`
+				};
+			}
+			if (error?.message?.includes("has no founders")) {
+				return {
+					reply: error.message
+				};
+			}
+		}
+
+		const { founders } = response.body;
+		if (!founders) {
 			return {
 				success: false,
-				reply: `There is no such channel with that name!`
+				reply: "Command execution failed! Please check your input."
 			};
 		}
 
 		const separator = (context.params.subStatus) ? " " : ", ";
-		const foundersString = response.body.founders.map(i => {
+		const foundersString = founders.map(i => {
 			let message = `${i.login[0]}\u{E0000}${i.login.slice(1)}`;
 			if (context.params.subStatus) {
 				const stillSubbed = (i.isSubscribed) ? "✅" : "⛔";


### PR DESCRIPTION
The command says, that the user does not exist, even if he does.

If user has no founders, the API responses with status 404, and with:
```json
{
  "error": {
    "message": "... has no founders"
  }
}
```

This PR is not the optimal solution, as it also looks quite bad, but its just to show how it could be solved.