### PR TITLE
Trim error response for `whatanimeisit` command

### DIFF
--- a/commands/whatanimeisit/index.js
+++ b/commands/whatanimeisit/index.js
@@ -30,7 +30,7 @@ module.exports = {
 
 		if (statusCode !== 200) {
 			const errorMessage = (data.error)
-				? data.error.replace(link, "")
+				? data.error.replace(link, "").trim()
 				: `Unknown error occured (status code ${statusCode})`;
 
 			return {


### PR DESCRIPTION
If you give the command for example an invalid link/ URL, the used API will respond with something like `"Invalid image url {providedLinkURL}"`.

We then take that response, remove the link, and then add an `"!"` at the end. However, by just removing the link, we leave a space at the end. So it will become something like `Invalid image url !`, which looks quite ugly in my opinion. So, before adding the `"!"`, we just trim the response.