### PR TITLE
Filter out any undefined/null values for `node` (`streaminfo` command)

### DIFF
--- a/commands/streaminfo/index.js
+++ b/commands/streaminfo/index.js
@@ -80,7 +80,7 @@ module.exports = {
 				};
 			}
 
-			const games = edges.map(i => i.node.displayName).join(", ");
+			const games = edges.filter(i => i?.node?.displayName).map(i => i.node.displayName).join(", ");
 			return {
 				reply: `Recently streamed categories: ${games}`
 			};

--- a/commands/streaminfo/index.js
+++ b/commands/streaminfo/index.js
@@ -80,7 +80,7 @@ module.exports = {
 				};
 			}
 
-			const games = edges.filter(i => i?.node?.displayName).map(i => i.node.displayName).join(", ");
+			const games = edges.filter(i => i.node?.displayName).map(i => i.node.displayName).join(", ");
 			return {
 				reply: `Recently streamed categories: ${games}`
 			};


### PR DESCRIPTION
When executing the `streaminfo` as followed, we get an error: `$si nymn summary:true` or `$si forsen summary:true`

The reason behind that, is, that the GQL API that we use, returns with something like this:
```json
[
    {
        "node": { }
    },
    {
        "node": { }
    }
]
```

However, sometimes we get something like this:
```json
[
    {
        "node": { }
    },
    {
        "node": null
    }
]
```
(I only tested the command with the two example streamers named at the beginning, however, I suppose that there are other cases where the same "error" would happen.)

Of course the [streaminfo command](https://github.com/Supinic/supibot-package-manager/blob/089c0550df10f391cde8570790efe4c559b713dc/commands/streaminfo/index.js#L83) doesn't expect `node` to be null, therefore we crash and get an error.

This PR should fix that error.