### PR TITLE
New Hungarian new source

### DIFF
--- a/commands/news/definitions.json
+++ b/commands/news/definitions.json
@@ -238,6 +238,13 @@
         "path": "24ora",
         "endpoints": ["rss"],
         "helpers": ["noiredayz"]
+      },
+      {
+	    "name": "Portfolio",
+	    "url": "https://portfolio.hu",
+	    "path": "rss",
+	    "endpoints": ["all.xml"],
+	    "helpers": ["noiredayz"]
       }
     ]
   },


### PR DESCRIPTION
Added a new Hungarian news source Portfolio.hu (mostly finance, economy and investment related news)